### PR TITLE
Added the PowerSurgeTech to kTechIdTable

### DIFF
--- a/lua/TechTreeConstants.lua
+++ b/lua/TechTreeConstants.lua
@@ -88,7 +88,7 @@ local kTechIdTable = {
     'Jetpack', 'JetpackFuelTech', 'JetpackArmorTech', 'Exosuit', 'ExosuitLockdownTech', 'ExosuitUpgradeTech',
     
     // Marine upgrades
-    'Weapons1', 'Weapons2', 'Weapons3', 'CatPackTech',
+    'Weapons1', 'Weapons2', 'Weapons3', 'CatPackTech', 'PowerSurgeTech',
     'Armor1', 'Armor2', 'Armor3', 'NanoArmor',
     
     // Activations


### PR DESCRIPTION
Not sure if i choose the right base branch but this "hofix" makes comp mod run with build 297 again.

The powersurge and grenade changes still need to be undone.